### PR TITLE
Update "Copy Coinlist" selector

### DIFF
--- a/export-coin-list.user.js
+++ b/export-coin-list.user.js
@@ -29,7 +29,7 @@
     const listItem = jQuery('<li></li>');
     listItem.append(button);
 
-    jQuery('.page-title-box .dropdown-menu').append(listItem);
+    jQuery('.btn-group.pull-right .dropdown-menu').append(listItem);
 
     button.on('click', () => exportCoinList());
   }

--- a/export-coin-list.user.js
+++ b/export-coin-list.user.js
@@ -2,7 +2,7 @@
 // @name         CryptoHopper Coin List Exporter
 // @namespace    https://github.com/coffeeneer/cryptohopper_scripts
 // @updateUrl    https://github.com/coffeeneer/cryptohopper_scripts/raw/main/export-coin-list.user.js
-// @version      0.1
+// @version      0.1.1
 // @description  Add an export option for the coin list on the Crypto Hopper Hopper config page
 // @author       coffeeneer
 // @match        https://www.cryptohopper.com/config
@@ -29,7 +29,7 @@
     const listItem = jQuery('<li></li>');
     listItem.append(button);
 
-    jQuery('.btn-group.pull-right .dropdown-menu').append(listItem);
+    jQuery('.c-page-heading__actions .btn-group .dropdown-menu').append(listItem);
 
     button.on('click', () => exportCoinList());
   }


### PR DESCRIPTION
The actions button on CryptoHopper's hopper config page has the following html:
``` html
<div class="btn-group pull-right" style="margin-top:-5px;">
    <button type="button" class="btn btn-default dropdown-toggle waves-effect waves-light" data-toggle="dropdown" aria-expanded="false"><span class="hidden-xs">Actions </span><span class="caret"></span></button>
    <ul class="dropdown-menu" role="menu">
        <li class="ms-hover"><a href="#" onclick="loadSlimscroll()" data-toggle="modal" data-target="#load_a_template_modal"><i class="fa fa-download m-r-5"></i> Load template</a></li>
        <li class="ms-hover"><a href="#" onclick="loadSlimscroll()" data-toggle="modal" data-target="#save_as_template_modal"><i class="fa fa-save m-r-5"></i> Save template</a></li>
                <li class="divider ms-hover"></li>
        <li class="ms-hover"><a href="/config?clone=" title="Clone bot"><i class="fa fa-clone m-r-5"></i> Clone bot</a></li>
    <li class="ms-hover"><a href="#"><i class="fa fa-copy m-r-5"></i> Copy coinlist</a></li></ul>
</div>
```

Previously the selector  was '.page-title-box .dropdown-menu'. It looks like CryptoHopper recently updated their website since no element with .page-title-box currently appears on the hopper config page. This commit updates the selector to match what's currently deployed on CryptoHopper.